### PR TITLE
feat: Tech Empire Tier 2 features

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -17,6 +17,9 @@ function App() {
   const [showTraining, setShowTraining] = useState(false);
   const [showHardware, setShowHardware] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [showRemaster, setShowRemaster] = useState(false);
+  const [remasterGame, setRemasterGame] = useState(null);
   const [showPublisher, setShowPublisher] = useState(false);
   const [publisherGame, setPublisherGame] = useState(null);
   const [pendingEvent, setPendingEvent] = useState(null);
@@ -251,6 +254,8 @@ function App() {
         showHardware={showHardware}
         onToggleHistory={() => setShowHistory(v => !v)}
         showHistory={showHistory}
+        onToggleSettings={() => setShowSettings(v => !v)}
+        showSettings={showSettings}
       />
 
       <GameScreen
@@ -345,6 +350,20 @@ function App() {
         <GameHistory
           state={gameState}
           onClose={() => setShowHistory(false)}
+          onRemaster={(g) => { setRemasterGame(g); setShowHistory(false); setShowRemaster(true); }}
+        />
+      )}
+
+      {showSettings && (
+        <SettingsPanel onClose={() => setShowSettings(false)} />
+      )}
+
+      {showRemaster && remasterGame && gameState && (
+        <RemasterWizard
+          state={gameState}
+          game={remasterGame}
+          onStart={() => { setShowRemaster(false); setRemasterGame(null); engine.setSpeed(1); }}
+          onCancel={() => { setShowRemaster(false); setRemasterGame(null); }}
         />
       )}
 
@@ -370,11 +389,24 @@ function App() {
             {gameState.gameOverReason === 'victory' ? (
               <>
                 <div style={{ fontSize: '48px', marginBottom: '16px' }}>&#127942;</div>
+                {gameState.victoryPath && (
+                  <div style={{
+                    fontSize: '12px', color: '#58a6ff', textTransform: 'uppercase',
+                    letterSpacing: '2px', marginBottom: '8px', fontWeight: 600,
+                  }}>
+                    {gameState.victoryPath}
+                  </div>
+                )}
                 <h2 style={{ fontSize: '28px', fontWeight: 800, color: '#3fb950', marginBottom: '12px' }}>
                   LEGENDARY STUDIO!
                 </h2>
                 <p style={{ fontSize: '15px', color: '#c9d1d9', marginBottom: '8px' }}>
-                  You reached $500M total revenue and 10M fans.
+                  {gameState.victoryPath === 'Brand Empire' && '50M fans and 10 critically acclaimed games.'}
+                  {gameState.victoryPath === 'Innovation Leader' && '3 moonshot AAA titles redefined the industry.'}
+                  {gameState.victoryPath === 'Market Dominator' && '15 games spanning 5 genres — you own every market.'}
+                  {gameState.victoryPath === 'Financial Titan' && '$1 billion in total revenue. A true empire.'}
+                  {gameState.victoryPath === 'Industry Kingmaker' && 'Hardware dominance — you set the standard.'}
+                  {!gameState.victoryPath && 'You built a legendary gaming empire!'}
                 </p>
                 <p style={{ fontSize: '13px', color: '#8b949e', marginBottom: '24px' }}>
                   Your studio will be remembered forever in gaming history.
@@ -387,7 +419,7 @@ function App() {
                   BANKRUPT
                 </h2>
                 <p style={{ fontSize: '15px', color: '#c9d1d9', marginBottom: '8px' }}>
-                  Your studio ran out of money for 12 consecutive weeks.
+                  Your studio ran out of money for too long.
                 </p>
                 <p style={{ fontSize: '13px', color: '#8b949e', marginBottom: '24px' }}>
                   The dream is over... but you can always try again.

--- a/src/renderer/components/PublisherPanel.js
+++ b/src/renderer/components/PublisherPanel.js
@@ -129,73 +129,104 @@ function PublisherPanel({ state, game, onSelectDeal, onSelfPublish, onClose }) {
               No publishers are interested yet. Build your reputation!
             </div>
           )}
-          {deals.map(deal => (
-            <div
-              key={deal.id}
-              className={`glass-card ${selectedId === deal.id ? 'glass-card-selected' : 'glass-card-hover'}`}
-              onClick={() => setSelectedId(deal.id)}
-              style={{
-                padding: '14px 16px',
-                marginBottom: '8px',
-                cursor: 'pointer',
-                border: selectedId === deal.id ? `1px solid ${deal.color}` : '1px solid rgba(255,255,255,0.08)',
-              }}
-            >
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                <div style={{ flex: 1 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
-                    <div style={{
-                      width: '8px', height: '8px', borderRadius: '50%',
-                      background: deal.color,
-                    }} />
-                    <span style={{ fontSize: '14px', fontWeight: 600, color: '#e6edf3' }}>
-                      {deal.name}
-                    </span>
-                    {deal.genreMatch && (
-                      <span style={{
-                        fontSize: '10px', padding: '2px 6px', borderRadius: '4px',
-                        background: 'rgba(63,185,80,0.15)', color: '#3fb950',
-                      }}>
-                        Genre Match
-                      </span>
-                    )}
-                  </div>
-                  <div style={{ fontSize: '11px', color: '#8b949e', marginBottom: '8px' }}>
-                    {deal.tagline}
+          {deals.map(deal => {
+            const isNeg = negotiatingId === deal.id;
+            const negTerms = isNeg ? getNegotiatedTerms(deal, negSlider) : null;
+            const counterTerms = isNeg && negRound === 1 ? getNegotiatedTerms(deal, counterSlider) : null;
+            return (
+              <div key={deal.id} style={{ marginBottom: '8px' }}>
+                <div
+                  className={`glass-card ${selectedId === deal.id && !isNeg ? 'glass-card-selected' : 'glass-card-hover'}`}
+                  onClick={() => { if (!isNeg) setSelectedId(deal.id); }}
+                  style={{
+                    padding: '14px 16px',
+                    cursor: isNeg ? 'default' : 'pointer',
+                    border: selectedId === deal.id ? `1px solid ${deal.color}` : '1px solid rgba(255,255,255,0.08)',
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                    <div style={{ flex: 1 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
+                        <div style={{ width: '8px', height: '8px', borderRadius: '50%', background: deal.color }} />
+                        <span style={{ fontSize: '14px', fontWeight: 600, color: '#e6edf3' }}>{deal.name}</span>
+                        {deal.genreMatch && (
+                          <span style={{ fontSize: '10px', padding: '2px 6px', borderRadius: '4px', background: 'rgba(63,185,80,0.15)', color: '#3fb950' }}>
+                            Genre Match
+                          </span>
+                        )}
+                      </div>
+                      <div style={{ fontSize: '11px', color: '#8b949e', marginBottom: '8px' }}>{deal.tagline}</div>
+                      <div style={{ display: 'flex', gap: '16px' }}>
+                        <div>
+                          <div style={{ fontSize: '10px', color: '#8b949e' }}>Advance</div>
+                          <div style={{ fontSize: '13px', fontWeight: 600, color: '#d29922' }}>{formatCash(deal.advance)}</div>
+                        </div>
+                        <div>
+                          <div style={{ fontSize: '10px', color: '#8b949e' }}>Their Cut</div>
+                          <div style={{ fontSize: '13px', fontWeight: 600, color: '#f85149' }}>{Math.round(deal.effectiveRoyaltyCut * 100)}%</div>
+                        </div>
+                        <div>
+                          <div style={{ fontSize: '10px', color: '#8b949e' }}>You Keep</div>
+                          <div style={{ fontSize: '13px', fontWeight: 600, color: '#3fb950' }}>{Math.round(deal.playerRevShare * 100)}%</div>
+                        </div>
+                      </div>
+                    </div>
+                    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '6px', minWidth: '90px' }}>
+                      <div style={{ textAlign: 'right' }}>
+                        <div style={{ fontSize: '10px', color: '#8b949e' }}>Est. Your Rev</div>
+                        <div style={{ fontSize: '16px', fontWeight: 700, color: '#3fb950' }}>{formatCash(deal.estimatedPlayerRevenue)}</div>
+                      </div>
+                      {!isNeg && (
+                        <button
+                          className="btn-secondary"
+                          style={{ fontSize: '11px', padding: '3px 10px', color: '#58a6ff', borderColor: 'rgba(88,166,255,0.3)' }}
+                          onClick={(e) => { e.stopPropagation(); setSelectedId(deal.id); setNegotiatingId(deal.id); setNegRound(0); setNegSlider(0); }}
+                        >
+                          Negotiate
+                        </button>
+                      )}
+                    </div>
                   </div>
 
-                  {/* Deal terms */}
-                  <div style={{ display: 'flex', gap: '16px' }}>
-                    <div>
-                      <div style={{ fontSize: '10px', color: '#8b949e' }}>Advance</div>
-                      <div style={{ fontSize: '13px', fontWeight: 600, color: '#d29922' }}>
-                        {formatCash(deal.advance)}
+                  {/* Negotiation UI */}
+                  {isNeg && (
+                    <div style={{ marginTop: '12px', padding: '12px', background: 'rgba(88,166,255,0.05)', borderRadius: '8px', border: '1px solid rgba(88,166,255,0.15)' }}>
+                      <div style={{ fontSize: '12px', color: '#58a6ff', fontWeight: 600, marginBottom: '8px' }}>
+                        {negRound === 0 ? 'Round 1: Make Your Offer' : `Round 2: Counter-Offer — ${deal.name} wants:`}
                       </div>
-                    </div>
-                    <div>
-                      <div style={{ fontSize: '10px', color: '#8b949e' }}>Their Cut</div>
-                      <div style={{ fontSize: '13px', fontWeight: 600, color: '#f85149' }}>
-                        {Math.round(deal.effectiveRoyaltyCut * 100)}%
-                      </div>
-                    </div>
-                    <div>
-                      <div style={{ fontSize: '10px', color: '#8b949e' }}>You Keep</div>
-                      <div style={{ fontSize: '13px', fontWeight: 600, color: '#3fb950' }}>
-                        {Math.round(deal.playerRevShare * 100)}%
-                      </div>
-                    </div>
-                  </div>
-                </div>
 
-                <div style={{ textAlign: 'right', minWidth: '90px' }}>
-                  <div style={{ fontSize: '10px', color: '#8b949e' }}>Est. Your Rev</div>
-                  <div style={{ fontSize: '16px', fontWeight: 700, color: '#3fb950' }}>
-                    {formatCash(deal.estimatedPlayerRevenue)}
-                  </div>
+                      {negRound === 1 && counterTerms && (
+                        <div style={{ display: 'flex', gap: '16px', marginBottom: '10px', padding: '8px', background: 'rgba(255,255,255,0.04)', borderRadius: '6px' }}>
+                          <div><div style={{ fontSize: '10px', color: '#8b949e' }}>Counter Advance</div><div style={{ fontSize: '13px', color: '#d29922', fontWeight: 600 }}>{formatCash(counterTerms.advance)}</div></div>
+                          <div><div style={{ fontSize: '10px', color: '#8b949e' }}>Their Cut</div><div style={{ fontSize: '13px', color: '#f85149', fontWeight: 600 }}>{Math.round(counterTerms.royaltyCut * 100)}%</div></div>
+                          <div><div style={{ fontSize: '10px', color: '#8b949e' }}>You Keep</div><div style={{ fontSize: '13px', color: '#3fb950', fontWeight: 600 }}>{Math.round(counterTerms.playerShare * 100)}%</div></div>
+                          <button className="btn-accent" style={{ fontSize: '11px', padding: '4px 12px', alignSelf: 'center' }} onClick={() => acceptCounter(deal)}>Accept Counter</button>
+                        </div>
+                      )}
+
+                      <div style={{ fontSize: '11px', color: '#8b949e', marginBottom: '6px' }}>
+                        Tilt: {negSlider < 0 ? 'Less advance, lower royalty' : negSlider > 0 ? 'More advance, higher royalty' : 'Base terms'}
+                      </div>
+                      <input type="range" min="-3" max="3" step="1" value={negSlider} onChange={e => setNegSlider(parseInt(e.target.value))} style={{ width: '100%', marginBottom: '8px' }} />
+                      {negTerms && (
+                        <div style={{ display: 'flex', gap: '16px', marginBottom: '10px' }}>
+                          <div><div style={{ fontSize: '10px', color: '#8b949e' }}>Your Offer: Advance</div><div style={{ fontSize: '13px', color: '#d29922', fontWeight: 600 }}>{formatCash(negTerms.advance)}</div></div>
+                          <div><div style={{ fontSize: '10px', color: '#8b949e' }}>Their Cut</div><div style={{ fontSize: '13px', color: '#f85149', fontWeight: 600 }}>{Math.round(negTerms.royaltyCut * 100)}%</div></div>
+                          <div><div style={{ fontSize: '10px', color: '#8b949e' }}>You Keep</div><div style={{ fontSize: '13px', color: '#3fb950', fontWeight: 600 }}>{Math.round(negTerms.playerShare * 100)}%</div></div>
+                        </div>
+                      )}
+                      <div style={{ display: 'flex', gap: '8px' }}>
+                        <button className="btn-secondary" style={{ fontSize: '11px', padding: '4px 10px' }} onClick={() => { setNegotiatingId(null); setNegRound(0); setNegSlider(0); }}>Cancel</button>
+                        <button className="btn-accent" style={{ fontSize: '11px', padding: '4px 12px' }} onClick={() => handleMakeOffer(deal)}>
+                          {negRound === 0 ? 'Send Offer' : 'Final Counter'}
+                        </button>
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
 
         {/* Action buttons */}

--- a/src/renderer/components/RemasterWizard.js
+++ b/src/renderer/components/RemasterWizard.js
@@ -1,0 +1,135 @@
+/**
+ * RemasterWizard — Pick new platforms for a remaster.
+ * Costs 30% of original dev cost. Score/reviews same as normal.
+ * Available for games released 5+ years ago.
+ */
+function RemasterWizard({ state, game, onStart, onCancel }) {
+  const [platformIds, setPlatformIds] = React.useState([]);
+
+  if (!state || !game) return null;
+
+  const availablePlatforms = state.availablePlatforms || [];
+  const sizeData = GAME_SIZES[game.size] || {};
+  const remasterCost = Math.round((sizeData.cost || 0) * 0.3);
+  const licenseFees = platformIds.reduce((sum, pid) => {
+    const p = PLATFORMS.find(pl => pl.id === pid);
+    return sum + (p ? p.licenseFee : 0);
+  }, 0);
+  const totalCost = remasterCost + licenseFees;
+  const canAfford = state.cash >= totalCost;
+
+  const togglePlatform = (id) => {
+    setPlatformIds(prev => {
+      if (prev.includes(id)) return prev.filter(x => x !== id);
+      if (prev.length >= 3) return prev;
+      return [...prev, id];
+    });
+  };
+
+  const formatCash = (n) => {
+    if (n >= 1000000) return '$' + (n / 1000000).toFixed(2) + 'M';
+    if (n >= 1000) return '$' + (n / 1000).toFixed(1) + 'K';
+    return '$' + n.toLocaleString();
+  };
+
+  const handleStart = () => {
+    if (platformIds.length === 0 || !canAfford) return;
+    engine.startRemaster(game, platformIds);
+    onStart();
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content" style={{ maxWidth: '520px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '20px' }}>
+          <div>
+            <div style={{ fontSize: '11px', color: '#da7cff', textTransform: 'uppercase', letterSpacing: '1px', marginBottom: '4px' }}>
+              Remaster
+            </div>
+            <h2 style={{ fontSize: '20px', fontWeight: 700, color: '#e6edf3', margin: 0 }}>
+              {game.title}
+            </h2>
+            <div style={{ fontSize: '12px', color: '#8b949e', marginTop: '4px' }}>
+              {game.genre} / {game.size} / Released Y{game.releaseYear} — Score {game.reviewAvg.toFixed(1)}
+            </div>
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontSize: '10px', color: '#8b949e' }}>Dev Cost</div>
+            <div style={{ fontSize: '16px', fontWeight: 700, color: '#d29922' }}>{formatCash(remasterCost)}</div>
+            <div style={{ fontSize: '10px', color: '#484f58' }}>30% of original</div>
+          </div>
+        </div>
+
+        {/* Info card */}
+        <div className="glass-card" style={{ padding: '12px 16px', marginBottom: '16px' }}>
+          <div style={{ fontSize: '12px', color: '#8b949e', lineHeight: 1.6 }}>
+            A remaster targets <strong style={{ color: '#e6edf3' }}>new platforms</strong> with 50% faster development.
+            Quality is based on the original game's reputation. Older titles gain a nostalgia bonus.
+          </div>
+        </div>
+
+        {/* Platform selection */}
+        <label style={{ fontSize: '13px', color: '#8b949e', display: 'block', marginBottom: '6px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+          Target Platforms <span style={{ color: '#484f58', textTransform: 'none' }}>(select 1–3)</span>
+        </label>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: '8px', marginBottom: '16px', maxHeight: '240px', overflowY: 'auto' }}>
+          {availablePlatforms.map(p => {
+            const selected = platformIds.includes(p.id);
+            const disabled = !selected && platformIds.length >= 3;
+            return (
+              <div
+                key={p.id}
+                className={`selection-item ${selected ? 'selected' : ''}`}
+                onClick={() => !disabled && togglePlatform(p.id)}
+                style={{ padding: '10px', textAlign: 'left', opacity: disabled ? 0.4 : 1, cursor: disabled ? 'not-allowed' : 'pointer' }}
+              >
+                <div style={{ fontWeight: 600, fontSize: '13px' }}>{p.name}</div>
+                <div style={{ fontSize: '11px', color: '#8b949e' }}>{p.company}</div>
+                <div style={{ fontSize: '11px', color: '#484f58', marginTop: '2px' }}>
+                  License: ${(p.licenseFee / 1000).toFixed(0)}K
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Cost summary */}
+        {platformIds.length > 0 && (
+          <div className="glass-card" style={{ padding: '10px 14px', marginBottom: '16px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px' }}>
+              <span style={{ color: '#8b949e' }}>Dev cost (30%)</span>
+              <span style={{ color: '#d29922' }}>{formatCash(remasterCost)}</span>
+            </div>
+            {licenseFees > 0 && (
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px', marginTop: '4px' }}>
+                <span style={{ color: '#8b949e' }}>License fees</span>
+                <span style={{ color: '#d29922' }}>{formatCash(licenseFees)}</span>
+              </div>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '13px', fontWeight: 600, marginTop: '8px', paddingTop: '8px', borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+              <span style={{ color: '#8b949e' }}>Total</span>
+              <span style={{ color: canAfford ? '#3fb950' : '#f85149' }}>{formatCash(totalCost)}</span>
+            </div>
+            {!canAfford && (
+              <div style={{ fontSize: '11px', color: '#f85149', marginTop: '4px' }}>
+                Insufficient funds (have {formatCash(state.cash)})
+              </div>
+            )}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button className="btn-secondary" onClick={onCancel} style={{ flex: 1 }}>Cancel</button>
+          <button
+            className="btn-accent"
+            onClick={handleStart}
+            disabled={platformIds.length === 0 || !canAfford}
+            style={{ flex: 1 }}
+          >
+            Start Remaster
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/SettingsPanel.js
+++ b/src/renderer/components/SettingsPanel.js
@@ -1,0 +1,169 @@
+/**
+ * SettingsPanel — Difficulty, autosave frequency, sound toggle, default speed, tutorial reset.
+ * Reads/writes to settingsSystem (localStorage, independent of save file).
+ */
+function SettingsPanel({ onClose }) {
+  const [difficulty, setDifficulty] = React.useState(settingsSystem.difficulty);
+  const [autosaveFreq, setAutosaveFreq] = React.useState(settingsSystem.autosaveFreq);
+  const [soundEnabled, setSoundEnabled] = React.useState(settingsSystem.soundEnabled);
+  const [defaultSpeed, setDefaultSpeed] = React.useState(settingsSystem.defaultSpeed);
+  const [saved, setSaved] = React.useState(false);
+
+  const handleSave = () => {
+    settingsSystem.setDifficulty(difficulty);
+    settingsSystem.setAutosaveFreq(autosaveFreq);
+    settingsSystem.setSoundEnabled(soundEnabled);
+    settingsSystem.setDefaultSpeed(defaultSpeed);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 1500);
+  };
+
+  const handleResetTutorial = () => {
+    localStorage.removeItem('techEmpire_tutorialComplete');
+    if (typeof tutorialSystem !== 'undefined') {
+      tutorialSystem.step = 0;
+      tutorialSystem.completed = false;
+    }
+    onClose();
+  };
+
+  const difficultyOptions = [
+    { value: 'Casual',   label: 'Casual',   desc: 'x1.5 revenue, no bankruptcy', color: '#3fb950' },
+    { value: 'Standard', label: 'Standard', desc: 'x1.0 revenue, 12-week buffer', color: '#58a6ff' },
+    { value: 'Hardcore', label: 'Hardcore', desc: 'x0.7 revenue, 6-week buffer',  color: '#f85149' },
+  ];
+
+  const autosaveOptions = [
+    { value: 2, label: 'Every 2 weeks' },
+    { value: 4, label: 'Every 4 weeks' },
+    { value: 8, label: 'Every 8 weeks' },
+  ];
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content" style={{ maxWidth: '440px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
+          <h2 style={{ fontSize: '20px', fontWeight: 700, color: '#e6edf3', margin: 0 }}>Settings</h2>
+          <button
+            onClick={onClose}
+            style={{ background: 'none', border: 'none', color: '#8b949e', fontSize: '20px', cursor: 'pointer', padding: '4px 8px', lineHeight: 1 }}
+          >
+            x
+          </button>
+        </div>
+
+        {/* Difficulty */}
+        <div style={{ marginBottom: '20px' }}>
+          <label style={{ fontSize: '13px', color: '#8b949e', display: 'block', marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+            Difficulty
+          </label>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            {difficultyOptions.map(opt => (
+              <div
+                key={opt.value}
+                className={`selection-item ${difficulty === opt.value ? 'selected' : ''}`}
+                onClick={() => setDifficulty(opt.value)}
+                style={{ flex: 1, padding: '12px', border: difficulty === opt.value ? `1px solid ${opt.color}` : '1px solid rgba(255,255,255,0.08)' }}
+              >
+                <div style={{ fontWeight: 600, fontSize: '13px', color: difficulty === opt.value ? opt.color : '#e6edf3' }}>
+                  {opt.label}
+                </div>
+                <div style={{ fontSize: '10px', color: '#8b949e', marginTop: '4px' }}>{opt.desc}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Autosave frequency */}
+        <div style={{ marginBottom: '20px' }}>
+          <label style={{ fontSize: '13px', color: '#8b949e', display: 'block', marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+            Autosave Frequency
+          </label>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            {autosaveOptions.map(opt => (
+              <div
+                key={opt.value}
+                className={`selection-item ${autosaveFreq === opt.value ? 'selected' : ''}`}
+                onClick={() => setAutosaveFreq(opt.value)}
+                style={{ flex: 1, padding: '10px', textAlign: 'center' }}
+              >
+                <div style={{ fontSize: '12px', fontWeight: 500 }}>{opt.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Default speed */}
+        <div style={{ marginBottom: '20px' }}>
+          <label style={{ fontSize: '13px', color: '#8b949e', display: 'block', marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+            Default Speed
+          </label>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            {[1, 2, 4].map(spd => (
+              <div
+                key={spd}
+                className={`selection-item ${defaultSpeed === spd ? 'selected' : ''}`}
+                onClick={() => setDefaultSpeed(spd)}
+                style={{ flex: 1, padding: '10px', textAlign: 'center' }}
+              >
+                <div style={{ fontSize: '14px', fontWeight: 600 }}>{spd}x</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Sound toggle */}
+        <div style={{ marginBottom: '24px' }}>
+          <label style={{ fontSize: '13px', color: '#8b949e', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+            Sound
+          </label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginTop: '10px' }}>
+            <div
+              onClick={() => setSoundEnabled(v => !v)}
+              style={{
+                width: '44px', height: '24px', borderRadius: '12px',
+                background: soundEnabled ? 'rgba(63,185,80,0.4)' : 'rgba(255,255,255,0.1)',
+                border: `1px solid ${soundEnabled ? '#3fb950' : 'rgba(255,255,255,0.15)'}`,
+                cursor: 'pointer', position: 'relative', transition: 'background 0.2s',
+              }}
+            >
+              <div style={{
+                width: '18px', height: '18px', borderRadius: '50%',
+                background: soundEnabled ? '#3fb950' : '#484f58',
+                position: 'absolute', top: '2px',
+                left: soundEnabled ? '22px' : '2px',
+                transition: 'left 0.2s',
+              }} />
+            </div>
+            <span style={{ fontSize: '13px', color: '#c9d1d9' }}>{soundEnabled ? 'On' : 'Off'}</span>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            className="btn-secondary"
+            onClick={handleResetTutorial}
+            style={{ fontSize: '12px', color: '#8b949e' }}
+          >
+            Reset Tutorial
+          </button>
+          <button
+            className="btn-secondary"
+            onClick={onClose}
+            style={{ flex: 1 }}
+          >
+            Cancel
+          </button>
+          <button
+            className="btn-accent"
+            onClick={handleSave}
+            style={{ flex: 1 }}
+          >
+            {saved ? 'Saved!' : 'Save Settings'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/TopBar.js
+++ b/src/renderer/components/TopBar.js
@@ -1,7 +1,7 @@
 /**
  * TopBar — Cash, fans, date, game progress, speed controls
  */
-function TopBar({ state, onSpeedChange, onToggleFinance, showFinance, onToggleResearch, showResearch, onToggleMarket, showMarket, onToggleMorale, showMorale, onToggleMarketing, showMarketing, onToggleTraining, showTraining, onToggleHardware, showHardware, onToggleHistory, showHistory }) {
+function TopBar({ state, onSpeedChange, onToggleFinance, showFinance, onToggleResearch, showResearch, onToggleMarket, showMarket, onToggleMorale, showMorale, onToggleMarketing, showMarketing, onToggleTraining, showTraining, onToggleHardware, showHardware, onToggleHistory, showHistory, onToggleSettings, showSettings }) {
   if (!state) return null;
 
   const formatCash = (n) => {
@@ -220,6 +220,19 @@ function TopBar({ state, onSpeedChange, onToggleFinance, showFinance, onToggleRe
             </svg>
           </button>
         )}
+
+        {/* Settings gear */}
+        <button
+          className={`speed-btn ${showSettings ? 'active' : ''}`}
+          onClick={onToggleSettings}
+          title="Settings"
+          style={{ fontWeight: 700, fontSize: '14px', lineHeight: 1 }}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style={{ verticalAlign: 'middle' }}>
+            <path d="M8 4.754a3.246 3.246 0 100 6.492 3.246 3.246 0 000-6.492zM5.754 8a2.246 2.246 0 114.492 0 2.246 2.246 0 01-4.492 0z"/>
+            <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 01-1.255.52l-.292-.16c-1.64-.892-3.434.901-2.54 2.541l.159.292a.873.873 0 01-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 01.52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 011.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 011.255-.52l.292.16c1.64.893 3.434-.901 2.54-2.541l-.159-.292a.873.873 0 01.52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 01-.52-1.255l.16-.292c.893-1.64-.901-3.434-2.541-2.54l-.292.159a.873.873 0 01-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 002.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 001.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 00-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 00-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 00-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 003.06 8.282l-.318-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 004.177 3.82l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 002.692-1.115l.094-.319z"/>
+          </svg>
+        </button>
 
         {/* Notification Center */}
         <NotificationCenter state={state} />

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -30,6 +30,7 @@
   <script src="../game/hardware.js"></script>
   <script src="../game/critics.js"></script>
   <script src="../game/taxes.js"></script>
+  <script src="../game/settings.js"></script>
   <script src="../game/engine.js"></script>
 
   <!-- Shared UI component library (load first — other components depend on these) -->
@@ -58,6 +59,8 @@
   <script type="text/babel" src="components/TutorialOverlay.js"></script>
   <script type="text/babel" src="components/TrainingPanel.js"></script>
   <script type="text/babel" src="components/HardwarePanel.js"></script>
+  <script type="text/babel" src="components/SettingsPanel.js"></script>
+  <script type="text/babel" src="components/RemasterWizard.js"></script>
   <script type="text/babel" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **US-001 Multi-platform release**: NewGameWizard allows selecting 1–3 platforms; each extra platform adds 50% dev time; revenue summed across all platforms
- **US-002 Remaster mechanic**: Remaster button in GameHistory for games 5+ years old; 30% dev cost; targets new platforms via RemasterWizard; nostalgia bonus from franchise tracker
- **US-003 Staff specialization**: Genre specialty badge (+20% quality if 25+ pts) and team lead crown (+10% productivity) shown in StaffPanel; both wired into `_devTick()`
- **US-004 Settings menu**: SettingsPanel with difficulty (Casual/Standard/Hardcore), autosave frequency, sound toggle, default speed; gear icon in TopBar; difficulty affects revenue multiplier and bankruptcy threshold
- **US-005 Publisher negotiation**: Negotiate button per deal; slider adjusts advance vs royalty cut tradeoff; publisher counter-offer in round 1; 2-round max; finalizes on round 2 or accepting counter
- **US-006 Employee drama events**: 8 staff events (poaching, raise demand, creative fight, side project viral, burnout, new skill learned, team celebration, office prank) added to EventSystem with morale consequences
- **5 Victory paths**: Brand Empire (50M fans + 10 high-score games), Innovation Leader (3 moonshots), Market Dominator (15 games / 5 genres), Financial Titan ($1B revenue), Industry Kingmaker (hardware $50M+); victory modal shows path name and flavor text

## Test plan

- [ ] NewGameWizard Step 3: can select 1, 2, or 3 platforms; 4th click is blocked; dev time warning shows
- [ ] Release a game on 2 platforms: revenue should be ~2x single-platform (minus difficulty multiplier)
- [ ] GameHistory detail view: Remaster button appears only on games released 5+ years ago with no active dev
- [ ] RemasterWizard: cost = 30% of size dev cost + license fees; starts dev at half normal time
- [ ] StaffPanel: team lead badge and genre specialty badges visible after training courses complete
- [ ] SettingsPanel: gear icon opens panel; save persists to localStorage; difficulty changes revenue immediately
- [ ] PublisherPanel: Negotiate opens slider; round 1 shows counter; round 2 finalizes
- [ ] Employee drama events fire in-game; EventModal handles adjustMorale consequence
- [ ] Play to one of the 5 victory conditions; modal shows correct path label

🤖 Generated with [Claude Code](https://claude.com/claude-code)