### PR TITLE
Keyboard shortcuts, brand polish, cross-platform builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,14 +255,14 @@ game-dev-empire/
 - [x] Save/load system
 - [x] Dev mode
 - [x] 100 automated tests, 100% pass rate (core engine, topics, scoring, finance, staff, gating, sales, victory, mid-game progression)
-- [x] macOS DMG packaging
+- [x] macOS DMG + zip (arm64/x64), Windows NSIS + portable, Linux AppImage + deb packaging configured
 
 ### Planned — Pre-Launch
 - [ ] Commissioned T1 raster art (office backgrounds, platform hardware, staff portraits)
-- [ ] T2 SVG icon families for topics, genres, achievements
+- [ ] T2 SVG icon families — genres (brand-request #32), topic themes (brand-request #33); achievements deferred until achievement system ships
 - [ ] Keyboard navigation and focus states
 - [ ] Steam distribution
-- [ ] Windows and Linux builds
+- [ ] Windows and Linux test builds + code signing (targets configured; need cert + CI signing pipeline)
 
 ### Post-Launch Expansion — 10 Additional Verticals (Assets Prepared)
 Launch version ships with the 4 core verticals above. The following expansion verticals

--- a/TEST-RESULTS.md
+++ b/TEST-RESULTS.md
@@ -1,6 +1,6 @@
 # Tech Empire -- Automated Test Results
 
-**Date:** 2026-04-05 18:10:28
+**Date:** 2026-04-05 18:32:17
 **Method:** Chrome DevTools Protocol (CDP) against live game instance
 **Total Tests:** 100
 **Passed:** 100
@@ -58,16 +58,16 @@
 | Status | Test | Detail |
 |--------|------|--------|
 | PASS | At least 1 game released | games count: 1 |
-| PASS | Game has avgScore between 1-10 | reviewAvg = 9.9 |
-| PASS | Revenue is positive | totalRevenue = 98392 |
-| PASS | Fans gained on release | fansGained = 50176 |
+| PASS | Game has avgScore between 1-10 | reviewAvg = 10 |
+| PASS | Revenue is positive | totalRevenue = 78045 |
+| PASS | Fans gained on release | fansGained = 50270 |
 | PASS | Sequel modifier applies for same title | sequel multiplier = 1.0499999999999998 |
 
 ## Financial (10/10 PASS)
 
 | Status | Test | Detail |
 |--------|------|--------|
-| PASS | Cash changed from initial $70K after release | cash = 94598 |
+| PASS | Cash changed from initial $70K after release | cash = 89511 |
 | PASS | Monthly expenses function exists |  |
 | PASS | Salary/rent transactions recorded after month tick | salary/rent records = 0 |
 | PASS | Tax system tick function exists |  |

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "dev": "electron . --dev",
     "build": "electron-builder",
     "build:mac": "electron-builder --mac",
+    "build:win": "electron-builder --win",
+    "build:linux": "electron-builder --linux",
+    "build:all": "electron-builder --mac --win --linux",
     "dist": "electron-builder --mac dmg",
     "test:e2e": "npx playwright test tests/e2e/"
   },
@@ -27,15 +30,38 @@
         "dmg",
         {
           "target": "zip",
-          "arch": [
-            "arm64"
-          ]
+          "arch": ["arm64", "x64"]
         }
       ],
+      "icon": "assets/brand/logo/logo-app-icon.jpg",
       "identity": null
+    },
+    "win": {
+      "target": [
+        { "target": "nsis", "arch": ["x64"] },
+        { "target": "portable", "arch": ["x64"] }
+      ],
+      "icon": "assets/brand/logo/logo-app-icon.jpg"
+    },
+    "linux": {
+      "category": "Game",
+      "target": [
+        { "target": "AppImage", "arch": ["x64"] },
+        { "target": "deb", "arch": ["x64"] }
+      ],
+      "icon": "assets/brand/logo/logo-app-icon.jpg",
+      "synopsis": "Tech Empire — game dev tycoon simulator",
+      "description": "Start solo in a garage, hire staff, research tech, ship hits, expand into 4 business verticals, and build a gaming empire."
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "createDesktopShortcut": true,
+      "createStartMenuShortcut": true
     },
     "files": [
       "src/**/*",
+      "assets/**/*",
       "package.json"
     ],
     "directories": {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -26,6 +26,7 @@ function createWindow() {
   log('INFO', `User data: ${app.getPath('userData')}`);
   log('INFO', `Log file: ${logPath}`);
 
+  const iconPath = path.join(__dirname, '..', '..', 'assets', 'brand', 'logo', 'logo-app-icon.jpg');
   mainWindow = new BrowserWindow({
     width: 1280,
     height: 800,
@@ -33,6 +34,7 @@ function createWindow() {
     minHeight: 700,
     title: 'Tech Empire',
     backgroundColor: '#0d1117',
+    icon: fs.existsSync(iconPath) ? iconPath : undefined,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -291,6 +291,80 @@ function App() {
     return () => { delete window._devAutoPlay; delete window._devLoadGame; };
   }, []);
 
+  // Keyboard shortcuts help overlay
+  const [showKeyboardHelp, setShowKeyboardHelp] = useState(false);
+
+  // Keyboard shortcuts — only active on game screen, ignored when typing in inputs
+  React.useEffect(() => {
+    const isTyping = () => {
+      const el = document.activeElement;
+      if (!el) return false;
+      const tag = el.tagName;
+      return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
+    };
+
+    // Close any open panel
+    const closeAllPanels = () => {
+      setShowStaff(false); setShowFinance(false); setShowResearch(false);
+      setShowMarket(false); setShowMorale(false); setShowMarketing(false);
+      setShowTraining(false); setShowHardware(false); setShowHistory(false);
+      setShowSettings(false); setShowVerticals(false); setShowStoryteller(false);
+      setShowTimeline(false); setShowCompetitors(false); setShowKeyboardHelp(false);
+    };
+
+    const anyPanelOpen = () =>
+      showStaff || showFinance || showResearch || showMarket || showMorale ||
+      showMarketing || showTraining || showHardware || showHistory || showSettings ||
+      showVerticals || showStoryteller || showTimeline || showCompetitors ||
+      showKeyboardHelp || showWizard || showReview || showPhaseModal || showConference ||
+      showIPO || showVictory || showRemaster || showPublisher || pendingEvent || eventConsequence;
+
+    const handleKey = (e) => {
+      if (isTyping()) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      // Escape closes any panel (including blocking modals)
+      if (e.key === 'Escape') {
+        closeAllPanels();
+        return;
+      }
+
+      // Ignore remaining shortcuts if a blocking modal is open
+      if (screen !== 'game') return;
+      if (showWizard || showReview || showPhaseModal || showConference ||
+          showIPO || showVictory || showRemaster || showPublisher ||
+          pendingEvent || eventConsequence) return;
+
+      switch (e.key) {
+        case ' ':
+          e.preventDefault();
+          engine.setSpeed(engine.speed === 0 ? 1 : 0);
+          break;
+        case '1': engine.setSpeed(0); break;
+        case '2': engine.setSpeed(1); break;
+        case '3': engine.setSpeed(2); break;
+        case '4': engine.setSpeed(4); break;
+        case 's': case 'S': if (!anyPanelOpen()) setShowStaff(true); break;
+        case 'f': case 'F': if (!anyPanelOpen()) setShowFinance(true); break;
+        case 'r': case 'R': if (!anyPanelOpen()) setShowResearch(true); break;
+        case 'm': case 'M': if (!anyPanelOpen()) setShowMarket(true); break;
+        case 'h': case 'H': if (!anyPanelOpen()) setShowHistory(true); break;
+        case 't': case 'T': if (!anyPanelOpen()) setShowTraining(true); break;
+        case 'c': case 'C': if (!anyPanelOpen()) setShowMarketing(true); break;
+        case 'v': case 'V': if (!anyPanelOpen()) setShowVerticals(true); break;
+        case '?': setShowKeyboardHelp(true); break;
+        default: break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [screen, showStaff, showFinance, showResearch, showMarket, showMorale,
+      showMarketing, showTraining, showHardware, showHistory, showSettings,
+      showVerticals, showStoryteller, showTimeline, showCompetitors, showKeyboardHelp,
+      showWizard, showReview, showPhaseModal, showConference, showIPO, showVictory,
+      showRemaster, showPublisher, pendingEvent, eventConsequence]);
+
   // Title screen
   if (screen === 'title') {
     const hasSave = !!localStorage.getItem('techEmpire_save');
@@ -332,12 +406,22 @@ function App() {
             Game Dev Tycoon
           </div>
           <div style={{
-            fontSize: '11px',
-            color: '#30363d',
+            display: 'inline-flex', alignItems: 'center', gap: '6px',
             marginTop: '8px',
-            letterSpacing: '2px',
           }}>
-            by Stark Labs
+            <img
+              src="../../assets/brand/logo/logo.svg"
+              alt=""
+              style={{ width: '16px', height: '16px', opacity: 0.6 }}
+              onError={(e) => { e.target.style.display = 'none'; }}
+            />
+            <span style={{
+              fontSize: '11px',
+              color: '#30363d',
+              letterSpacing: '2px',
+            }}>
+              by Stark Labs
+            </span>
           </div>
         </div>
 
@@ -601,6 +685,10 @@ function App() {
 
       {showSettings && (
         <SettingsPanel onClose={() => setShowSettings(false)} />
+      )}
+
+      {showKeyboardHelp && (
+        <KeyboardHelpModal onClose={() => setShowKeyboardHelp(false)} />
       )}
 
       {showRemaster && remasterGame && gameState && (

--- a/src/renderer/components/KeyboardHelpModal.js
+++ b/src/renderer/components/KeyboardHelpModal.js
@@ -1,0 +1,64 @@
+/**
+ * KeyboardHelpModal — Reference card for all keyboard shortcuts.
+ * Triggered by "?" key. Closes on Escape or click-outside.
+ */
+function KeyboardHelpModal({ onClose }) {
+  React.useEffect(() => {
+    const h = (e) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', h);
+    return () => document.removeEventListener('keydown', h);
+  }, [onClose]);
+
+  const Row = ({ keys, label }) => (
+    <div className="kbhelp-row">
+      <div className="kbhelp-keys">
+        {keys.map((k, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <span className="kbhelp-or">or</span>}
+            <kbd className="kbhelp-key">{k}</kbd>
+          </React.Fragment>
+        ))}
+      </div>
+      <div className="kbhelp-label">{label}</div>
+    </div>
+  );
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content kbhelp-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="kbhelp-header">
+          <div>
+            <div className="panel-header" style={{ marginBottom: '4px' }}>Reference</div>
+            <h2 className="kbhelp-title">Keyboard Shortcuts</h2>
+          </div>
+          <button className="modal-close-btn" onClick={onClose}>&times;</button>
+        </div>
+
+        <div className="kbhelp-section-title">Game Speed</div>
+        <Row keys={['Space']}   label="Pause / Resume" />
+        <Row keys={['1']}       label="Pause (speed 0)" />
+        <Row keys={['2']}       label="Normal (1x)" />
+        <Row keys={['3']}       label="Fast (2x)" />
+        <Row keys={['4']}       label="Very Fast (4x)" />
+
+        <div className="kbhelp-section-title">Open Panel</div>
+        <Row keys={['S']}       label="Staff" />
+        <Row keys={['F']}       label="Finance" />
+        <Row keys={['R']}       label="Research" />
+        <Row keys={['T']}       label="Training" />
+        <Row keys={['C']}       label="Campaigns (marketing)" />
+        <Row keys={['V']}       label="Verticals" />
+        <Row keys={['M']}       label="Market" />
+        <Row keys={['H']}       label="Game History" />
+
+        <div className="kbhelp-section-title">Utility</div>
+        <Row keys={['Esc']}     label="Close any open panel" />
+        <Row keys={['?']}       label="Show this reference" />
+
+        <div className="kbhelp-footer">
+          Shortcuts are disabled while typing in inputs.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -71,6 +71,7 @@
   <script type="text/babel" src="components/TrainingPanel.js"></script>
   <script type="text/babel" src="components/HardwarePanel.js"></script>
   <script type="text/babel" src="components/SettingsPanel.js"></script>
+  <script type="text/babel" src="components/KeyboardHelpModal.js"></script>
   <script type="text/babel" src="components/RemasterWizard.js"></script>
   <script type="text/babel" src="components/VerticalPanel.js"></script>
   <script type="text/babel" src="components/StorytellerPanel.js"></script>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1219,6 +1219,47 @@ input[type="range"]::-webkit-slider-thumb:hover {
 
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   KeyboardHelpModal
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.kbhelp-modal { max-width: 480px; }
+.kbhelp-header {
+  display: flex; justify-content: space-between; align-items: flex-start;
+  margin-bottom: var(--space-5);
+}
+.kbhelp-title {
+  font-size: 22px; font-weight: 700; color: var(--color-text-primary); margin: 0;
+}
+.kbhelp-section-title {
+  font-size: var(--text-xs); color: var(--color-text-secondary);
+  text-transform: uppercase; letter-spacing: 0.5px; font-weight: 600;
+  margin: var(--space-4) 0 var(--space-2);
+  padding-bottom: 4px; border-bottom: 1px solid var(--color-border);
+}
+.kbhelp-section-title:first-of-type { margin-top: 0; }
+.kbhelp-row {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: 6px 0;
+}
+.kbhelp-keys { display: flex; align-items: center; gap: 4px; min-width: 90px; }
+.kbhelp-key {
+  display: inline-block; padding: 3px 8px; min-width: 24px; text-align: center;
+  background: var(--color-surface-raised); border: 1px solid var(--color-border);
+  border-bottom-width: 2px; border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px; font-weight: 600; color: var(--color-text-primary);
+}
+.kbhelp-or { font-size: 10px; color: var(--color-text-tertiary); }
+.kbhelp-label { font-size: var(--text-sm); color: var(--color-text-body); }
+.kbhelp-footer {
+  margin-top: var(--space-5); padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+  font-size: var(--text-xs); color: var(--color-text-tertiary);
+  text-align: center;
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════════
    Review Screen
    ═══════════════════════════════════════════════════════════════════════════ */
 


### PR DESCRIPTION
## Summary
- Adds keyboard shortcuts + help overlay (Space to pause, S/F/R/T/C/V/M/H to open panels, ? for reference)
- Wires Stark Labs logo mark into title screen + Electron window icon
- Configures electron-builder for Windows (NSIS + portable) and Linux (AppImage + deb), expands macOS to arm64+x64
- **Critical fix:** adds `assets/**/*` to build.files — packaged app was shipping without any assets
- Files 2 brand requests with CCO for T2 SVG icon families (#32 genres, #33 topic themes)

## What changed

### Keyboard shortcuts (`src/renderer/app.js`, `src/renderer/components/KeyboardHelpModal.js`)
New `useEffect` listens for global keydown and dispatches:
- **Game speed:** Space (pause/resume), 1/2/3/4 (speeds)
- **Panels:** S=Staff, F=Finance, R=Research, T=Training, C=Campaigns, V=Verticals, M=Market, H=History
- **Utility:** Esc (close any panel), ? (help overlay)
- Disabled while typing in `<input>`/`<textarea>`/`<select>` (checks `document.activeElement`)
- New `KeyboardHelpModal` component shows the full reference when `?` is pressed

### Brand polish
- `src/renderer/app.js` — Stark Labs hexagon logo renders inline with "by Stark Labs" on title screen
- `src/main/main.js` — `logo-app-icon.jpg` passed as BrowserWindow `icon` (with fs.existsSync guard)

### Cross-platform builds (`package.json`)
- Added `build:win`, `build:linux`, `build:all` scripts
- `build.win`: NSIS installer with desktop/start-menu shortcuts + portable exe (x64)
- `build.linux`: AppImage + deb (x64) with category="Game"
- `build.mac`: expanded zip arch to `arm64, x64`
- Window/installer icons pinned to `logo-app-icon.jpg`
- **Fixed asset packaging:** `"assets/**/*"` added to `build.files` (was only shipping `src/**/*` + `package.json` — packaged binaries were asset-less)

### CCO brand requests filed (not in this PR — separate GitHub issues)
- #32: Genre icon family (6 icons, P2)
- #33: Topic theme icon family (12 icons, P3)
- Engineering provides specs + delivery paths; CCO owns production
- Achievement icons intentionally deferred — achievement system doesn't exist in game yet

## Test plan
- [x] `python3 tests/cdp_test_suite.py` — 100/100 pass
- [x] `npx playwright test tests/e2e/title-screen.spec.js` — 7/7 pass
- [ ] Manual smoke: launch game, press `?`, verify shortcut overlay renders; press `S`/`Esc`/etc. to verify each shortcut
- [ ] Manual smoke: `npm run build:win` on Windows CI to verify NSIS builds
- [ ] Manual smoke: `npm run build:linux` on Linux CI to verify AppImage builds
- [ ] Verify packaged DMG contains `assets/` directory (prior packages would have been broken)

## Notes
Focus-visible styles were already in `styles.css` (line 641) — the DESIGN-SYSTEM.md "Planned" note was stale. Docs updated in README.